### PR TITLE
Add schematron check/fix for name/id mismatch

### DIFF
--- a/people/b/bierman-everett-e.xml
+++ b/people/b/bierman-everett-e.xml
@@ -6,13 +6,13 @@
         <forename>Everett E.</forename>
     </persName>
     <birth>1924</birth>
-    <death type=""/>
+    <death>2017</death>
     <career-type>non-career</career-type>
     <residence>
         <state-id>va</state-id>
     </residence>
     <created-by>wicentowskijc</created-by>
     <created-date>2010-05-20</created-date>
-    <last-modified-by>wicentowskijc</last-modified-by>
-    <last-modified-date>2012-08-10</last-modified-date>
+    <last-modified-by>marrsaw</last-modified-by>
+    <last-modified-date>2017-07-26</last-modified-date>
 </person>

--- a/people/i/irving-frederick.xml
+++ b/people/i/irving-frederick.xml
@@ -6,13 +6,13 @@
         <forename>Frederick</forename>
     </persName>
     <birth>1921</birth>
-    <death type=""/>
+    <death>2016</death>
     <career-type>career</career-type>
     <residence>
         <state-id>ri</state-id>
     </residence>
     <created-by>wicentowskijc</created-by>
     <created-date>2010-05-20</created-date>
-    <last-modified-by>wicentowskijc</last-modified-by>
-    <last-modified-date>2010-05-20</last-modified-date>
+    <last-modified-by>marrsaw</last-modified-by>
+    <last-modified-date>2017-07-27</last-modified-date>
 </person>

--- a/people/p/pezzulo-lawrence-a.xml
+++ b/people/p/pezzulo-lawrence-a.xml
@@ -7,13 +7,13 @@
         <altname>Lawrence Pezzulo</altname>
     </persName>
     <birth>1926</birth>
-    <death type=""/>
+    <death>2017</death>
     <career-type>career</career-type>
     <residence>
         <state-id>md</state-id>
     </residence>
     <created-by>wicentowskijc</created-by>
     <created-date>2010-05-20</created-date>
-    <last-modified-by>wicentowskijc</last-modified-by>
-    <last-modified-date>2010-05-20</last-modified-date>
+    <last-modified-by>marrsaw</last-modified-by>
+    <last-modified-date>2017-07-27</last-modified-date>
 </person>

--- a/positions-principals/assistant-secretary-non-proliferation.xml
+++ b/positions-principals/assistant-secretary-non-proliferation.xml
@@ -4,7 +4,7 @@
     <class>principal</class>
     <category>discontinued</category>
     <names>
-        <singular>Assistant Secretaries of State for Non-Proliferation</singular>
+        <singular>Assistant Secretary of State for Non-Proliferation</singular>
         <plural>Assistant Secretaries of State for Non-Proliferation</plural>
     </names>
     <start accuracy="yyyy">1999</start>

--- a/schema/person.sch
+++ b/schema/person.sch
@@ -10,11 +10,22 @@
         <rule context="id">
             <let name="basename" value="replace(base-uri(.), '^.*/(.*?)$', '$1')"/>
             <let name="parent-dir" value="replace(base-uri(.), '^.*/(.*?)/.*?$', '$1')"/>
+            <let name="original-id" value="./string()"/>
+            <let name="generated-id" value="lower-case(replace(replace(string-join(./following-sibling::persName/(surname, forename, genName), ' '), '\p{P}', ''), '\s+', '-'))"/>
             <assert test="$basename = concat(., '.xml')">The id “<value-of select="."/>” does
                 not match filename “<value-of select="$basename"/>”</assert>
             <assert test="$parent-dir = substring(., 1, 1)">The file should be stored in the “<value-of select="substring(., 1, 1)"/>” directory, not in the “<value-of select="$parent-dir"/>” directory</assert>
             <assert test="matches(., '^[a-z-]+(\d+)?$')">The id 
                 “<value-of select="."/>” must contain only lower case letters and hyphens, and can optionally end with a number</assert>
+            <assert test=". eq $generated-id" sqf:fix="update-id">Based on the name elements, the ID should be <value-of select="$generated-id"/>.</assert>
+            <sqf:fix id="update-id">
+                <sqf:description>
+                    <sqf:title>Update ID from name</sqf:title>
+                </sqf:description>
+                <sqf:add use-when="not(following-sibling::old-ids)" match="." position="after" target="old-ids" node-type="element"/>
+                <sqf:add match="following-sibling::old-ids" target="old-id" node-type="element"><value-of select="$original-id"/></sqf:add>
+                <sqf:replace match="." target="id" node-type="element" select="$generated-id"/>
+            </sqf:fix>
         </rule>
     </pattern>
     <pattern>

--- a/schema/person.sch
+++ b/schema/person.sch
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt3"
+    xmlns:sch="http://purl.oclc.org/dsdl/schematron"
     xmlns:sqf="http://www.schematron-quickfix.com/validator/process">
     <pattern>
         <rule context="/">
@@ -22,9 +23,17 @@
                 <sqf:description>
                     <sqf:title>Update ID from name</sqf:title>
                 </sqf:description>
-                <sqf:add use-when="not(following-sibling::old-ids)" match="." position="after" target="old-ids" node-type="element"/>
-                <sqf:add match="following-sibling::old-ids" target="old-id" node-type="element"><value-of select="$original-id"/></sqf:add>
-                <sqf:replace match="." target="id" node-type="element" select="$generated-id"/>
+                <sqf:add use-when="not(following-sibling::old-ids)" match="." position="after" target="old-ids" node-type="element">
+                    <old-id xmlns="">
+                        <sch:value-of select="$original-id"/>
+                    </old-id>
+                </sqf:add>
+                <sqf:add use-when="following-sibling::old-ids"  match="following-sibling::old-ids" position="last-child">
+                    <old-id xmlns="">
+                        <sch:value-of select="$original-id"/>
+                    </old-id>
+                </sqf:add>
+                <sqf:replace match="text()" select="$generated-id"/>
             </sqf:fix>
         </rule>
     </pattern>


### PR DESCRIPTION
- when a name no longer matches the id, a schematron quick fix appears (in oXygen) on the <id> element offering to update the id
- what this quick fix does is (1) move the out-of-date id into an <old-id> element, creating the parent <old-ids> wrapper if needed, and (2) update the id with the current contents of the name field
- this should replace the manual steps 3 & 4 for updating IDs in https://github.com/HistoryAtState/pocom/wiki/person-names-and-ids
- unfortunately, the steps in 5-10 (changing the filenames, committing/deleting/uploading) can’t be done by schematron quick fixes. it also can’t make toast.
- but hopefully this relieves us of some burden of manually making these changes, and reduces the chances for error to creep in
- thanks to Octavian Nadu (@octavianN), one of the developers of the amazing oXygen XML Editor, for making this commit possible with his quick and thorough answers to my questions at https://github.com/schematron-quickfix/sqf/issues/20.