### PR TITLE
Improve handling of reserved characters in template processing

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -26,12 +26,18 @@
         <echo message="Apply values to expath-pkg.xml..."/>
         <copy todir="${build.dir}/${app.name}-${app.version}" overwrite="true" verbose="true">
             <fileset file="expath-pkg.xml.tmpl"/>
-            <filterset>
-                <filter token="name" value="${app.name}"/>
-                <filter token="version" value="${app.version}"/>
-                <filter token="url" value="${app.url}"/>
-                <filter token="title" value="${app.title}"/>
-            </filterset>
+            <filterchain>
+                <replacetokens>
+                    <token key="name" value="${app.name}"/>
+                    <token key="version" value="${app.version}"/>
+                    <token key="url" value="${app.url}"/>
+                    <token key="title" value="${app.title}"/>                    
+                </replacetokens>
+                <tokenfilter>
+                    <!-- until we move template processing to XSLT, take care with reserved characters -->
+                    <replacestring from="&amp;" to="&amp;amp;"/>
+                </tokenfilter>
+            </filterchain>
             <globmapper from="*.tmpl" to="*"/>
         </copy>
     </target>
@@ -131,6 +137,6 @@
             <exclude name="${build.dir}/**"/>
             <exclude name="**/*.tmpl"/>
         </zip>
-        <delete dir="${build.dir}/${app.name}-${app.version}"/>
+<!--        <delete dir="${build.dir}/${app.name}-${app.version}"/>-->
     </target>
 </project>

--- a/build.xml
+++ b/build.xml
@@ -47,14 +47,20 @@
         <copy todir="${build.dir}/${app.name}-${app.version}" overwrite="true" verbose="true">
             <fileset file="collection.xconf.tmpl"/>
             <fileset file="expath-pkg.xml.tmpl"/>
-            <filterset>
-                <filter token="provider-url" value="${trigger.provider-url.dev}"/>
-                <filter token="destination" value="${trigger.destination.dev}"/>
-                <filter token="name" value="${app.name}"/>
-                <filter token="version" value="${app.version}"/>
-                <filter token="url" value="${app.url}"/>
-                <filter token="title" value="${app.title}"/>
-            </filterset>
+            <filterchain>
+                <replacetokens>
+                    <token key="provider-url" value="${trigger.provider-url.dev}"/>
+                    <token key="destination" value="${trigger.destination.dev}"/>
+                    <token key="name" value="${app.name}"/>
+                    <token key="version" value="${app.version}"/>
+                    <token key="url" value="${app.url}"/>
+                    <token key="title" value="${app.title}"/>
+                </replacetokens>
+                <tokenfilter>
+                    <!-- until we move template processing to XSLT, take care with reserved characters -->
+                    <replacestring from="&amp;" to="&amp;amp;"/>
+                </tokenfilter>
+            </filterchain>
             <globmapper from="*.tmpl" to="*"/>
         </copy>
     </target>
@@ -64,14 +70,20 @@
         <copy todir="${build.dir}/${app.name}-${app.version}" overwrite="true" verbose="true">
             <fileset file="collection.xconf.tmpl"/>
             <fileset file="expath-pkg.xml.tmpl"/>
-            <filterset>
-                <filter token="provider-url" value="${trigger.provider-url.prod}"/>
-                <filter token="destination" value="${trigger.destination.prod}"/>
-                <filter token="name" value="${app.name}"/>
-                <filter token="version" value="${app.version}"/>
-                <filter token="url" value="${app.url}"/>
-                <filter token="title" value="${app.title}"/>
-            </filterset>
+            <filterchain>
+                <replacetokens>
+                    <token key="provider-url" value="${trigger.provider-url.prod}"/>
+                    <token key="destination" value="${trigger.destination.prod}"/>
+                    <token key="name" value="${app.name}"/>
+                    <token key="version" value="${app.version}"/>
+                    <token key="url" value="${app.url}"/>
+                    <token key="title" value="${app.title}"/>
+                </replacetokens>
+                <tokenfilter>
+                    <!-- until we move template processing to XSLT, take care with reserved characters -->
+                    <replacestring from="&amp;" to="&amp;amp;"/>
+                </tokenfilter>
+            </filterchain>
             <globmapper from="*.tmpl" to="*"/>
         </copy>
     </target>
@@ -137,6 +149,6 @@
             <exclude name="${build.dir}/**"/>
             <exclude name="**/*.tmpl"/>
         </zip>
-<!--        <delete dir="${build.dir}/${app.name}-${app.version}"/>-->
+        <delete dir="${build.dir}/${app.name}-${app.version}"/>
     </target>
 </project>


### PR DESCRIPTION
We use ant to filter template files, replacing tokens like `@title@` in [expath-pkg.xml.tmpl](https://github.com/HistoryAtState/pocom/blob/master/expath-pkg.xml.tmpl#L3) (e.g., `<title>@title@</title>`) with values defined in [build.properties.xml](https://github.com/HistoryAtState/pocom/blob/master/build.properties.xml#L6) (e.g., `<title>Principal Officers &amp; Chiefs of Mission (data)</title>`) to produce a new expath-pkg.xml file. The source in build.properties.xml is valid XML, but because Ant's filters don't take XML serialization rules into account, the resulting output file expath-pkg.xml becomes invalid XML, with an unescaped ampersand. This PR switches our processing from ant `<filterset>` to `<filterchain>`, which supports pipelines. 

Sources:
- https://stackoverflow.com/a/49785973/659732
- @xquery's book - https://books.google.com/books?id=RC1899T2MM4C&lpg=PA13&ots=h4h7VUIUWp&dq=ant%20apply%20filterchain%20to%20filterset&pg=PA14#v=onepage&q=%22understanding%20filterchains%22%20&f=false

This is an attempt at a more robust approach to the same problem identified in https://github.com/HistoryAtState/pocom/pull/21.